### PR TITLE
Add conceptFrom functions for ConceptAs and deprecate static from methods

### DIFF
--- a/Source/concepts/ConceptAs.ts
+++ b/Source/concepts/ConceptAs.ts
@@ -2,8 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import { IEquatable } from '@dolittle/rudiments';
-import { typeGuard } from '@dolittle/types';
-import { MissingUniqueConceptName } from './MissingUniqueConceptName';
+import { typeGuard, Constructor } from '@dolittle/types';
+import { MissingUniqueConceptName } from './index';
 
 type ConceptBase = number | bigint | string | boolean | IEquatable;
 
@@ -46,6 +46,7 @@ export class ConceptAs<T extends ConceptBase, U extends string> implements IEqua
      * @template T
      * @template U
      * @param {T} concept
+     * @deprecated Use
      * @returns {C}
      */
     static from<C extends ConceptAs<T, U>, T extends ConceptBase, U extends string>(concept: ConceptAs<T, U> | T, uniqueConceptName?: U): C {
@@ -90,6 +91,7 @@ export class ConceptAs<T extends ConceptBase, U extends string> implements IEqua
      * @template C
      * @template U
      * @param {boolean} value
+     * @deprecated
      * @returns {C}
      */
     static fromBoolean<T extends boolean, C extends ConceptAs<T, U>, U extends string>(value: boolean, uniqueConceptName: U): C {
@@ -124,4 +126,11 @@ export class ConceptAs<T extends ConceptBase, U extends string> implements IEqua
     toString(): string {
         return this.value.toString();
     }
+}
+
+export function conceptFrom<C extends ConceptAs<T, U>, T extends ConceptBase, U extends string>(conceptConstructor: Constructor<C>, concept: T): C {
+    return new conceptConstructor(concept) as C;
+}
+export function conceptFromFor<C extends ConceptAs<T, U>, T extends ConceptBase, U extends string>(conceptConstructor: Constructor<C>): (concept: T) => C {
+    return (concept: T) => new conceptConstructor(concept) as C;
 }

--- a/Source/concepts/ConceptAs.ts
+++ b/Source/concepts/ConceptAs.ts
@@ -46,7 +46,7 @@ export class ConceptAs<T extends ConceptBase, U extends string> implements IEqua
      * @template T
      * @template U
      * @param {T} concept
-     * @deprecated Use
+     * @deprecated
      * @returns {C}
      */
     static from<C extends ConceptAs<T, U>, T extends ConceptBase, U extends string>(concept: ConceptAs<T, U> | T, uniqueConceptName?: U): C {
@@ -62,6 +62,7 @@ export class ConceptAs<T extends ConceptBase, U extends string> implements IEqua
      * @template C
      * @template U
      * @param {number} value
+     * @deprecated
      * @returns {C}
      */
     static fromNumber<C extends ConceptAs<number, U>, U extends string>(value: number, uniqueConceptName: U): C {
@@ -76,6 +77,7 @@ export class ConceptAs<T extends ConceptBase, U extends string> implements IEqua
      * @template C
      * @template U
      * @param {string} value
+     * @deprecated
      * @returns {C}
      */
     static fromString<C extends ConceptAs<string, U>, U extends string>(value: string, uniqueConceptName: U): C {
@@ -128,9 +130,9 @@ export class ConceptAs<T extends ConceptBase, U extends string> implements IEqua
     }
 }
 
-export function conceptFrom<C extends ConceptAs<T, U>, T extends ConceptBase, U extends string>(conceptConstructor: Constructor<C>, concept: T): C {
+export function conceptFrom<C extends ConceptAs<T, U>, T extends ConceptBase, U extends string>(conceptConstructor: Constructor<ConceptAs<T, U>>, concept: T): C {
     return new conceptConstructor(concept) as C;
 }
-export function conceptFromFor<C extends ConceptAs<T, U>, T extends ConceptBase, U extends string>(conceptConstructor: Constructor<C>): (concept: T) => C {
-    return (concept: T) => new conceptConstructor(concept) as C;
+export function conceptFromFor<C extends ConceptAs<T, U>, T extends ConceptBase, U extends string>(conceptConstructor: Constructor<ConceptAs<T, U>>): (concept: T) => C {
+    return (concept: T) => conceptFrom(conceptConstructor, concept) as C;
 }

--- a/Source/concepts/for_ConceptAs/when_creating_concept/as_concept_from.ts
+++ b/Source/concepts/for_ConceptAs/when_creating_concept/as_concept_from.ts
@@ -1,0 +1,19 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { some_concept, some_base } from '../given/some_concept';
+import { ConceptAs, conceptFrom  } from '../../index';
+
+describe('when creating some concept with conceptFrom', () => {
+    const value = new some_base('some_x', 42);
+    const concept = conceptFrom(some_concept, value);
+
+    it('should be a concept', () => ConceptAs.isConcept(concept).should.be.true);
+    it('should have the correct value', () => concept.value.should.equal(value));
+    it('should equal the value', () => concept.equals(value).should.be.true);
+    it('should equal itself', () => concept.equals(concept).should.be.true);
+    it('should equal the same concept with the same value', () => concept.equals(new some_concept(value)).should.be.true);
+    it('should not equal the same concept with another value', () => concept.equals(new some_concept(new some_base('some other value', 1))).should.be.false);
+    it('should not equal to another concept with the same something', () => concept.equals(ConceptAs.from(value, '')).should.be.false);
+    it('should not equal to another concept with another something', () => concept.equals(ConceptAs.from(new some_base('some other value', 1), '')).should.be.false);
+});

--- a/Source/concepts/for_ConceptAs/when_creating_concept/from_number.ts
+++ b/Source/concepts/for_ConceptAs/when_creating_concept/from_number.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { ConceptAs } from '../../ConceptAs';
+import { ConceptAs, conceptFrom } from '../../ConceptAs';
 
 describe('when creating concept from number', () => {
     const value = 2;

--- a/Source/concepts/index.ts
+++ b/Source/concepts/index.ts
@@ -1,4 +1,5 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-export * from './ConceptAs';
+export { MissingUniqueConceptName } from './MissingUniqueConceptName';
+export { ConceptAs, conceptFrom } from './ConceptAs';

--- a/Source/concepts/index.ts
+++ b/Source/concepts/index.ts
@@ -2,4 +2,4 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 export { MissingUniqueConceptName } from './MissingUniqueConceptName';
-export { ConceptAs, conceptFrom } from './ConceptAs';
+export { ConceptAs, conceptFrom, conceptFromFor } from './ConceptAs';


### PR DESCRIPTION
Can use the functions like this:

```
class SomeId extends ConceptAs<Guid, 'SomeId'> {
    constructor(id: Guid) {
        super(id, 'SomeId');   
    }
}

export function SomeIdFrom(id: Guid): SomeId {
    return conceptFrom(SomeId, id);
    // or return conceptFromFor(SomeId)(id);
}

const someId = SomeIdFrom(Guid.create());
```